### PR TITLE
DS-2756: Add GET Findings (Index & Show) API documentation

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1434,16 +1434,17 @@ JSON.parse(response)
     "type": null,
     "status": "closed",
     "priority": "high",
-    "creation_date": "2026-01-30T19:53:52.528+00:00",
-    "expiration_date": "2026-01-23T19:53:00.000+00:00",
-    "closure_date": "2026-02-05T15:23:12.360+00:00",
+    "creation_date": "30/01/2026 19:53",
+    "expiration_date": "23/01/2026 19:53",
+    "closure_date": "05/02/2026 15:23",
     "closure_message": "Addressed",
-    "location_name": "Main Office",
+    "location": "Main Office",
+    "nestable_location": null,
     "creator_name": "Juan Perez",
     "assignees": "Juan Perez, Maria Lopez",
     "invitees": "Carlos Silva",
     "last_updated_by": "Juan Perez",
-    "form_answer_id": 12345,
+    "form_answer_code": "FA-12345",
     "task_form_title": "Daily Inspection",
     "task_form_question": "What issues were found?"
   }
@@ -1464,8 +1465,8 @@ start | String | Optional. Start date in `dd-mm-yyyy` format. Defaults to 7 days
 end | String | Optional. End date in `dd-mm-yyyy` format. Defaults to today
 status | String | Optional. Filter by status: `open`, `in_progress`, `paused`, `closed`
 task_form_id | Integer | Optional. Filter by the ID of the associated form. Only returns tickets linked to that form
-limit | Integer | Optional. Max number of results to return. Default: 200
-offset | Integer | Optional. Number of results to skip (for pagination). Default: 0
+limit | Integer | Optional. Max number of results to return. Default: 200, max: 200
+offset | Integer | Optional. Number of results to skip (for pagination). Default: 0, max: 10000
 
 The maximum allowed date range is **90 days**. Requests with a wider range will return `422 Unprocessable Entity`.
 
@@ -1489,16 +1490,17 @@ description | String | Ticket description
 type | String | Ticket Type ID (null if no type assigned)
 status | String | Current status: `open`, `in_progress`, `paused`, `closed`
 priority | String | Priority level: `low`, `medium`, `high`, `critical`
-creation_date | Datetime | Date and time the ticket was created (ISO 8601)
-expiration_date | Datetime | Date and time the ticket expires (ISO 8601)
-closure_date | Datetime | Date and time the ticket was closed (null if not closed)
+creation_date | String | Date and time the ticket was created, formatted according to account preferences (e.g. `30/01/2026 19:53`)
+expiration_date | String | Date and time the ticket expires, formatted according to account preferences (null if none)
+closure_date | String | Date and time the ticket was closed, formatted according to account preferences (null if not closed)
 closure_message | String | Message provided when closing the ticket (null if not closed)
-location_name | String | Name of the associated location (null if none)
+location | String | Name of the associated standard location (null if a nestable location or none)
+nestable_location | String | Name of the associated nestable location (null if a standard location or none)
 creator_name | String | Full name of the user who created the ticket
 assignees | String | Comma-separated list of assigned users' full names
 invitees | String | Comma-separated list of invited users' full names (empty string if none)
 last_updated_by | String | Full name of the user who last updated the ticket (null if not available)
-form_answer_id | Integer | ID of the linked form answer (null if none)
+form_answer_code | String | Code of the linked form answer (null if none)
 task_form_title | String | Title of the linked form (null if no form answer linked)
 task_form_question | String | Question from the linked form answer (null if no form answer linked)
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1463,6 +1463,7 @@ Parameter | Type | Description
 start | String | Optional. Start date in `dd-mm-yyyy` format. Defaults to 7 days ago
 end | String | Optional. End date in `dd-mm-yyyy` format. Defaults to today
 status | String | Optional. Filter by status: `open`, `in_progress`, `paused`, `closed`
+task_form_id | Integer | Optional. Filter by the ID of the associated form. Only returns tickets linked to that form
 limit | Integer | Optional. Max number of results to return. Default: 200
 offset | Integer | Optional. Number of results to skip (for pagination). Default: 0
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1468,6 +1468,15 @@ offset | Integer | Optional. Number of results to skip (for pagination). Default
 
 The maximum allowed date range is **90 days**. Requests with a wider range will return `422 Unprocessable Entity`.
 
+### Pagination
+
+Results are paginated using `limit` and `offset`. `limit` controls how many results are returned, and `offset` controls how many to skip from the beginning.
+
+For example, if there are 400 tickets in the period:
+
+- First page: `limit=200&offset=0` → returns tickets 1–200
+- Second page: `limit=200&offset=200` → returns tickets 201–400
+
 ### Response Fields
 
 Field | Type | Description

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1406,7 +1406,7 @@ TIP: It will only start sending information for the new forms done after the int
 ## Get Tickets by Period
 
 ```shell
-curl "https://www.mydatascope.com/api/external/findings?start=01-01-2026&end=31-01-2026"
+curl "https://www.mydatascope.com/api/external/findings/list?start=01-01-2026&end=31-01-2026"
   -H "Authorization: b1cd93mfls9fdmfkadn23"
 ```
 
@@ -1414,7 +1414,7 @@ curl "https://www.mydatascope.com/api/external/findings?start=01-01-2026&end=31-
 require 'rest-client'
 require 'json'
 
-url = 'https://www.mydatascope.com/api/external/findings'
+url = 'https://www.mydatascope.com/api/external/findings/list'
 response = RestClient.get url, {
 :Authorization => 'b1cd93mfls9fdmfkadn23',
  :params => { start: '01-01-2026', end: '31-01-2026' }
@@ -1468,7 +1468,7 @@ This endpoint retrieves a list of Tickets filtered by creation date period.
 
 ### HTTP Request
 
-`GET https://www.mydatascope.com/api/external/findings`
+`GET https://www.mydatascope.com/api/external/findings/list`
 
 ### Input Parameters
 
@@ -1541,7 +1541,7 @@ Remember — use your own header Authorization
 ## Get Ticket
 
 ```shell
-curl "https://www.mydatascope.com/api/external/findings/Krdz3aFoWZ4ZVgpuAart"
+curl "https://www.mydatascope.com/api/external/findings/get/Krdz3aFoWZ4ZVgpuAart"
   -H "Authorization: b1cd93mfls9fdmfkadn23"
 ```
 
@@ -1549,7 +1549,7 @@ curl "https://www.mydatascope.com/api/external/findings/Krdz3aFoWZ4ZVgpuAart"
 require 'rest-client'
 require 'json'
 
-url = 'https://www.mydatascope.com/api/external/findings/Krdz3aFoWZ4ZVgpuAart'
+url = 'https://www.mydatascope.com/api/external/findings/get/Krdz3aFoWZ4ZVgpuAart'
 response = RestClient.get url, {
 :Authorization => 'b1cd93mfls9fdmfkadn23',
 }
@@ -1586,7 +1586,7 @@ This endpoint retrieves a single Ticket by its Firestore document ID.
 
 ### HTTP Request
 
-`GET https://www.mydatascope.com/api/external/findings/:id`
+`GET https://www.mydatascope.com/api/external/findings/get/:id`
 
 ### URL Parameter
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1431,19 +1431,32 @@ JSON.parse(response)
     "code": 1,
     "name": "ejemplo",
     "description": "Ejemplo",
-    "type": null,
+    "type": "Safety",
     "status": "closed",
     "priority": "high",
     "creation_date": "30/01/2026 19:53",
     "expiration_date": "23/01/2026 19:53",
     "closure_date": "05/02/2026 15:23",
     "closure_message": "Addressed",
-    "location": "Main Office",
-    "nestable_location": null,
+    "location_id": 42,
+    "location_name": "Main Office",
+    "location_code": "LOC-001",
+    "asset_name": null,
+    "asset_identifier": null,
+    "creator_id": 7,
+    "creator_email": "juan.perez@example.com",
     "creator_name": "Juan Perez",
-    "assignees": "Juan Perez, Maria Lopez",
-    "invitees": "Carlos Silva",
+    "assignees_concatenated": "user_id:7;;email:juan.perez@example.com;;name:Juan Perez&&user_id:12;;email:maria.lopez@example.com;;name:Maria Lopez",
+    "invitees_concatenated": "user_id:18;;email:carlos.silva@example.com;;name:Carlos Silva",
+    "assignees": {
+      "0": { "id": 7, "full_name": "Juan Perez", "email": "juan.perez@example.com" },
+      "1": { "id": 12, "full_name": "Maria Lopez", "email": "maria.lopez@example.com" }
+    },
+    "invitees": {
+      "0": { "id": 18, "full_name": "Carlos Silva", "email": "carlos.silva@example.com" }
+    },
     "last_updated_by": "Juan Perez",
+    "form_answer_id": 101,
     "form_answer_code": "FA-12345",
     "task_form_title": "Daily Inspection",
     "task_form_question": "What issues were found?"
@@ -1466,7 +1479,7 @@ end | String | Optional. End date in `dd-mm-yyyy` format. Defaults to today
 status | String | Optional. Filter by status: `open`, `in_progress`, `paused`, `closed`
 task_form_id | Integer | Optional. Filter by the ID of the associated form. Only returns tickets linked to that form
 limit | Integer | Optional. Max number of results to return. Default: 200, max: 200
-offset | Integer | Optional. Number of results to skip (for pagination). Default: 0, max: 10000
+offset | Integer | Optional. Number of results to skip (for pagination). Default: 0, max: 2000
 
 The maximum allowed date range is **90 days**. Requests with a wider range will return `422 Unprocessable Entity`.
 
@@ -1487,19 +1500,27 @@ id | String | Firestore document ID
 code | Integer | Sequential ticket number within the account
 name | String | Ticket name
 description | String | Ticket description
-type | String | Ticket Type ID (null if no type assigned)
+type | String | Resolved ticket type name (null if no type assigned)
 status | String | Current status: `open`, `in_progress`, `paused`, `closed`
 priority | String | Priority level: `low`, `medium`, `high`, `critical`
 creation_date | String | Date and time the ticket was created, formatted according to account preferences (e.g. `30/01/2026 19:53`)
 expiration_date | String | Date and time the ticket expires, formatted according to account preferences (null if none)
 closure_date | String | Date and time the ticket was closed, formatted according to account preferences (null if not closed)
 closure_message | String | Message provided when closing the ticket (null if not closed)
-location | String | Name of the associated standard location (null if a nestable location or none)
-nestable_location | String | Name of the associated nestable location (null if a standard location or none)
+location_id | Integer | Database ID of the associated location (null if none)
+location_name | String | Name of the associated location (null if none)
+location_code | String | Code of the associated location (null if none)
+asset_name | String | Name of the linked asset (null if none)
+asset_identifier | String | Code/identifier of the linked asset (null if none)
+creator_id | Integer | Database ID of the user who created the ticket
+creator_email | String | Email of the user who created the ticket
 creator_name | String | Full name of the user who created the ticket
-assignees | String | Comma-separated list of assigned users' full names
-invitees | String | Comma-separated list of invited users' full names (empty string if none)
+assignees_concatenated | String | Assigned users as a `&&`-separated string, each entry formatted as `user_id:{id};;email:{email};;name:{name}` (empty string if none)
+invitees_concatenated | String | Invited users as a `&&`-separated string, same format as `assignees_concatenated` (empty string if none)
+assignees | Object | Assigned users as an indexed object: `{ "0": { "id": Integer, "full_name": String, "email": String }, ... }` (empty object if none)
+invitees | Object | Invited users as an indexed object, same shape as `assignees` (empty object if none)
 last_updated_by | String | Full name of the user who last updated the ticket (null if not available)
+form_answer_id | Integer | Database ID of the linked form answer (null if none)
 form_answer_code | String | Code of the linked form answer (null if none)
 task_form_title | String | Title of the linked form (null if no form answer linked)
 task_form_question | String | Question from the linked form answer (null if no form answer linked)
@@ -1508,7 +1529,7 @@ task_form_question | String | Question from the linked form answer (null if no f
 
 ```
 200: OK
-403: Forbidden
+401: Unauthorized
 422: Unprocessable Entity (invalid date range or range exceeds 90 days)
 ```
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1536,3 +1536,96 @@ task_form_question | String | Question from the linked form answer (null if no f
 <aside class="success">
 Remember — use your own header Authorization
 </aside>
+
+
+## Get Ticket
+
+```shell
+curl "https://www.mydatascope.com/api/external/findings/Krdz3aFoWZ4ZVgpuAart"
+  -H "Authorization: b1cd93mfls9fdmfkadn23"
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+url = 'https://www.mydatascope.com/api/external/findings/Krdz3aFoWZ4ZVgpuAart'
+response = RestClient.get url, {
+:Authorization => 'b1cd93mfls9fdmfkadn23',
+}
+JSON.parse(response)
+```
+
+> The above command returns JSON structured like this, you can check the description of each parameter below:
+
+```json
+{
+  "id": "Krdz3aFoWZ4ZVgpuAart",
+  "code": 1,
+  "name": "ejemplo",
+  "description": "Ejemplo",
+  "type": null,
+  "status": "closed",
+  "priority": "high",
+  "creation_date": "2026-01-30T19:53:52.528+00:00",
+  "expiration_date": "2026-01-23T19:53:00.000+00:00",
+  "closure_date": "2026-02-05T15:23:12.360+00:00",
+  "closure_message": "Addressed",
+  "location_name": "Main Office",
+  "creator_name": "Juan Perez",
+  "assignees": "Juan Perez, Maria Lopez",
+  "invitees": "Carlos Silva",
+  "last_updated_by": "Juan Perez",
+  "form_answer_id": 12345,
+  "task_form_title": "Daily Inspection",
+  "task_form_question": "What issues were found?"
+}
+```
+
+This endpoint retrieves a single Ticket by its Firestore document ID.
+
+### HTTP Request
+
+`GET https://www.mydatascope.com/api/external/findings/:id`
+
+### URL Parameter
+
+Parameter | Type | Description
+--------- | ------- | -----------
+id | String | Required. The Firestore document ID of the ticket. This can be obtained from the ticket URL in the DataScope web app (`?selected=<id>`)
+
+### Response Fields
+
+Field | Type | Description
+--------- | ------- | -----------
+id | String | Firestore document ID
+code | Integer | Sequential ticket number within the account
+name | String | Ticket name
+description | String | Ticket description
+type | String | Ticket Type ID (null if no type assigned)
+status | String | Current status: `open`, `in_progress`, `paused`, `closed`
+priority | String | Priority level: `low`, `medium`, `high`, `critical`
+creation_date | Datetime | Date and time the ticket was created (ISO 8601)
+expiration_date | Datetime | Date and time the ticket expires (ISO 8601)
+closure_date | Datetime | Date and time the ticket was closed (null if not closed)
+closure_message | String | Message provided when closing the ticket (null if not closed)
+location_name | String | Name of the associated location (null if none)
+creator_name | String | Full name of the user who created the ticket
+assignees | String | Comma-separated list of assigned users' full names
+invitees | String | Comma-separated list of invited users' full names (empty string if none)
+last_updated_by | String | Full name of the user who last updated the ticket (null if not available)
+form_answer_id | Integer | ID of the linked form answer (null if none)
+task_form_title | String | Title of the linked form (null if no form answer linked)
+task_form_question | String | Question from the linked form answer (null if no form answer linked)
+
+### Return Codes
+
+```
+200: OK
+404: Not Found
+403: Forbidden
+```
+
+<aside class="success">
+Remember — use your own header Authorization
+</aside>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1397,5 +1397,109 @@ To configure the webhook you need to go to the Integrations section and then Web
 ```
 
 <aside class="notice">
-TIP: It will only start sending information for the new forms done after the integration. 
+TIP: It will only start sending information for the new forms done after the integration.
+</aside>
+
+
+# Tickets (FKA Issues)
+
+## Get Tickets by Period
+
+```shell
+curl "https://www.mydatascope.com/api/external/findings?start=01-01-2026&end=31-01-2026"
+  -H "Authorization: b1cd93mfls9fdmfkadn23"
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+url = 'https://www.mydatascope.com/api/external/findings'
+response = RestClient.get url, {
+:Authorization => 'b1cd93mfls9fdmfkadn23',
+ :params => { start: '01-01-2026', end: '31-01-2026' }
+}
+JSON.parse(response)
+```
+
+> The above command returns JSON structured like this, you can check the description of each parameter below:
+
+```json
+[
+  {
+    "id": "Krdz3aFoWZ4ZVgpuAart",
+    "code": 1,
+    "name": "ejemplo",
+    "description": "Ejemplo",
+    "type": null,
+    "status": "closed",
+    "priority": "high",
+    "creation_date": "2026-01-30T19:53:52.528+00:00",
+    "expiration_date": "2026-01-23T19:53:00.000+00:00",
+    "closure_date": "2026-02-05T15:23:12.360+00:00",
+    "closure_message": "Addressed",
+    "location_name": "Main Office",
+    "creator_name": "Juan Perez",
+    "assignees": "Juan Perez, Maria Lopez",
+    "invitees": "Carlos Silva",
+    "last_updated_by": "Juan Perez",
+    "form_answer_id": 12345,
+    "task_form_title": "Daily Inspection",
+    "task_form_question": "What issues were found?"
+  }
+]
+```
+
+This endpoint retrieves a list of Tickets filtered by creation date period.
+
+### HTTP Request
+
+`GET https://www.mydatascope.com/api/external/findings`
+
+### Input Parameters
+
+Parameter | Type | Description
+--------- | ------- | -----------
+start | String | Optional. Start date in `dd-mm-yyyy` format. Defaults to 7 days ago
+end | String | Optional. End date in `dd-mm-yyyy` format. Defaults to today
+status | String | Optional. Filter by status: `open`, `in_progress`, `paused`, `closed`
+limit | Integer | Optional. Max number of results to return. Default: 200
+offset | Integer | Optional. Number of results to skip (for pagination). Default: 0
+
+The maximum allowed date range is **90 days**. Requests with a wider range will return `422 Unprocessable Entity`.
+
+### Response Fields
+
+Field | Type | Description
+--------- | ------- | -----------
+id | String | Firestore document ID
+code | Integer | Sequential ticket number within the account
+name | String | Ticket name
+description | String | Ticket description
+type | String | Ticket Type ID (null if no type assigned)
+status | String | Current status: `open`, `in_progress`, `paused`, `closed`
+priority | String | Priority level: `low`, `medium`, `high`, `critical`
+creation_date | Datetime | Date and time the ticket was created (ISO 8601)
+expiration_date | Datetime | Date and time the ticket expires (ISO 8601)
+closure_date | Datetime | Date and time the ticket was closed (null if not closed)
+closure_message | String | Message provided when closing the ticket (null if not closed)
+location_name | String | Name of the associated location (null if none)
+creator_name | String | Full name of the user who created the ticket
+assignees | String | Comma-separated list of assigned users' full names
+invitees | String | Comma-separated list of invited users' full names (empty string if none)
+last_updated_by | String | Full name of the user who last updated the ticket (null if not available)
+form_answer_id | Integer | ID of the linked form answer (null if none)
+task_form_title | String | Title of the linked form (null if no form answer linked)
+task_form_question | String | Question from the linked form answer (null if no form answer linked)
+
+### Return Codes
+
+```
+200: OK
+403: Forbidden
+422: Unprocessable Entity (invalid date range or range exceeds 90 days)
+```
+
+<aside class="success">
+Remember — use your own header Authorization
 </aside>


### PR DESCRIPTION
## Summary

- Documents the `GET /api/external/findings` index endpoint, including input parameters, pagination, response fields, and return codes
- Documents the `GET /api/external/findings/:id` show endpoint, including URL parameters, response fields, and return codes
- Organizes both endpoints under a new **Tickets (FKA Issues)** section in the public API docs

## Test plan

- [ ] Review rendered Slate docs to confirm both endpoints display correctly
- [ ] Verify all parameters, response fields, and return codes match the actual Rails implementation
- [ ] Confirm pagination documentation is accurate
- [ ] Check that filter parameters (e.g., `task_form_id`, date range) are properly described

🤖 Generated with [Claude Code](https://claude.com/claude-code)