### PR TITLE
docs(DS-2757): rename start_date/end_date to start/end

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1232,6 +1232,112 @@ code | String | Code to identify the task
 Remember — user your own header Authorization
 </aside>
 
+## Get Task Assign by ID
+
+```shell
+curl "https://www.mydatascope.com/api/external/task_assigns/4821" \
+  -H "Authorization: b1cd93mfls9fdmfkadn23"
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+url = 'https://www.mydatascope.com/api/external/task_assigns/4821'
+response = RestClient.get url, {
+  :Authorization => 'b1cd93mfls9fdmfkadn23'
+}
+JSON.parse(response)
+```
+
+> The above command returns JSON structured like this, you can check the description of each parameter below:
+
+```json
+{
+  "id": 4821,
+  "assign_id": "TA-2024-001",
+  "form_answer_code": "FA-0099",
+  "start_time": "2025-03-10 09:00:00",
+  "form_name": "Safety Inspection",
+  "user_email": "inspector@company.com",
+  "description": "Monthly fire extinguisher check",
+  "location_name": "Main Warehouse",
+  "location_code": "WH-001",
+  "location_type": "Location",
+  "location_address": "123 Main Ave",
+  "location_email": "warehouse@company.com",
+  "location_phone": "+1-555-0100",
+  "gap": 2,
+  "checklist": "Check extinguisher,Verify seal,Sign log",
+  "location_latitude": -33.4489,
+  "location_longitude": -70.6693,
+  "completed": "Yes",
+  "on_time": "Yes",
+  "delay_time": "0d/00h/00m",
+  "completed_datetime": "2025-03-10 10:45:00",
+  "late_response_allowed": false,
+  "mandatory": "for_everyone",
+  "confirmation_status": "completed",
+  "status": "completed",
+  "time_to_perform_minutes": 105.5,
+  "datetime_start": "2025-03-10 09:05:00",
+  "datetime_end": "2025-03-10 10:45:00",
+  "created_at": "2025-03-01 08:00:00",
+  "created_by": "Admin User"
+}
+```
+
+This endpoint retrieves the full detail of a single task assignment by its internal ID. Returns the same fields as the list endpoint. Returns 404 if the assignment does not belong to the authenticated account.
+
+### HTTP Request
+
+`GET https://www.mydatascope.com/api/external/task_assigns/:id`
+
+### Path Parameters
+
+Parameter | Type | Description
+--------- | ------- | -----------
+id | Integer | Internal database ID of the task assignment
+
+### Response Fields
+
+Field | Type | Description
+--------- | ------- | -----------
+id | Integer | Internal database ID — unique across all periods
+assign_id | String | User-defined task code — may repeat across periods
+form_answer_code | String | Code of the submitted form answer, if completed
+start_time | String | Scheduled start time (account timezone)
+form_name | String | Name of the associated form
+user_email | String | Email of the assigned inspector
+description | String | Task description or instructions
+location_name | String | Name of the location
+location_code | String | Code of the location
+location_type | String | `Location` or `NestableLocation`
+location_address | String | Address of the location
+location_email | String | Email of the location
+location_phone | String | Phone of the location
+gap | Integer | Estimated hours to perform the task
+checklist | String | Comma-separated checklist items
+location_latitude | Float | Latitude of the location
+location_longitude | Float | Longitude of the location
+completed | String | `Yes` if a form answer exists, `No` otherwise
+on_time | String | `Yes` if completed before deadline, `No` if late, `null` if not completed
+delay_time | String | Delay formatted as `Xd/HHh/MMm`. `null` if not completed
+completed_datetime | String | When the last answer was submitted (account timezone)
+late_response_allowed | Boolean | Whether late submissions are permitted
+mandatory | String | `for_nobody`, `for_one`, or `for_everyone`
+confirmation_status | String | Acceptance state: `required`, `accepted`, `rejected`, `completed`, or `null`
+status | String | Task state: `completed`, `incomplete`, `sent`, `in_progress`, or `rejected`
+time_to_perform_minutes | Float | Minutes between first and last answer submission. `null` if not completed
+datetime_start | String | When the first answer was submitted (account timezone)
+datetime_end | String | When the last answer was submitted (account timezone)
+created_at | String | When the task assignment was created (account timezone)
+created_by | String | Full name of the user who created the task assignment
+
+<aside class="success">
+Remember — use your own Authorization header
+</aside>
+
 # Notifications
 
 ## List Last notifications

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1256,7 +1256,8 @@ JSON.parse(response)
 {
   "id": 4821,
   "assign_id": "TA-2024-001",
-  "form_answer_code": "FA-0099",
+  "response_code": "FA-0099",
+  "priority": 1,
   "start_time": "2025-03-10 09:00:00",
   "form_name": "Safety Inspection",
   "user_email": "inspector@company.com",
@@ -1305,7 +1306,8 @@ Field | Type | Description
 --------- | ------- | -----------
 id | Integer | Internal database ID — unique across all periods
 assign_id | String | User-defined task code — may repeat across periods
-form_answer_code | String | Code of the submitted form answer, if completed
+response_code | String | Code of the submitted form answer, if completed
+priority | Integer | Task priority level (set when creating the task)
 start_time | String | Scheduled start time (account timezone)
 form_name | String | Name of the associated form
 user_email | String | Email of the assigned inspector
@@ -1365,7 +1367,8 @@ JSON.parse(response)
     {
       "id": 4821,
       "assign_id": "TA-2024-001",
-      "form_answer_code": "FA-0099",
+      "response_code": "FA-0099",
+  "priority": 1,
       "start_time": "2025-03-10 09:00:00",
       "form_name": "Safety Inspection",
       "user_email": "inspector@company.com",
@@ -1425,7 +1428,8 @@ Field | Type | Description
 --------- | ------- | -----------
 id | Integer | Internal database ID — unique across all periods
 assign_id | String | User-defined task code — may repeat across periods
-form_answer_code | String | Code of the submitted form answer, if completed
+response_code | String | Code of the submitted form answer, if completed
+priority | Integer | Task priority level (set when creating the task)
 start_time | String | Scheduled start time (account timezone)
 form_name | String | Name of the associated form
 user_email | String | Email of the assigned inspector

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1343,7 +1343,7 @@ Remember — use your own Authorization header
 ## Get Task Assigns by Period
 
 ```shell
-curl "https://www.mydatascope.com/api/external/task_assigns?start_date=2025-03-01&end_date=2025-03-31" \
+curl "https://www.mydatascope.com/api/external/task_assigns?start=2025-03-01&end=2025-03-31" \
   -H "Authorization: b1cd93mfls9fdmfkadn23"
 ```
 
@@ -1354,7 +1354,7 @@ require 'json'
 url = 'https://www.mydatascope.com/api/external/task_assigns'
 response = RestClient.get url, {
   :Authorization => 'b1cd93mfls9fdmfkadn23',
-  :params => { start_date: '2025-03-01', end_date: '2025-03-31' }
+  :params => { start: '2025-03-01', end: '2025-03-31' }
 }
 JSON.parse(response)
 ```
@@ -1414,8 +1414,8 @@ This endpoint retrieves a paginated list of task assignments for the authenticat
 
 Parameter | Type | Description
 --------- | ------- | -----------
-start_date | String | Optional. Start date in `YYYY-MM-DD` format. Filters by `start_time >= date`
-end_date | String | Optional. End date in `YYYY-MM-DD` format. Filters by `start_time <= date`
+start | String | Optional. Start date in `YYYY-MM-DD` format. Filters by `start_time >= date`
+end | String | Optional. End date in `YYYY-MM-DD` format. Filters by `start_time <= date`
 status | String | Optional. Filter by status: `completed`, `incomplete`, `assigned`, `accepted`, `rejected`
 location_id | Integer | Optional. Filter by location ID
 user_email | String | Optional. Filter by the assigned inspector's email

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1281,8 +1281,8 @@ JSON.parse(response)
   "confirmation_status": "completed",
   "status": "completed",
   "time_to_perform_minutes": 105.5,
-  "datetime_start": "2025-03-10 09:05:00",
-  "datetime_end": "2025-03-10 10:45:00",
+  "response_start": "2025-03-10 09:05:00",
+  "response_end": "2025-03-10 10:45:00",
   "created_at": "2025-03-01 08:00:00",
   "created_by": "Admin User"
 }
@@ -1331,8 +1331,8 @@ mandatory | String | `for_nobody`, `for_one`, or `for_everyone`
 confirmation_status | String | Acceptance state: `required`, `accepted`, `rejected`, `completed`, or `null`
 status | String | Task state: `completed`, `incomplete`, `assigned`, `accepted`, or `rejected`
 time_to_perform_minutes | Float | Minutes between first and last answer submission. `null` if not completed
-datetime_start | String | When the first answer was submitted (account timezone)
-datetime_end | String | When the last answer was submitted (account timezone)
+response_start | String | When the first answer was submitted (account timezone)
+response_end | String | When the last answer was submitted (account timezone)
 created_at | String | When the task assignment was created (account timezone)
 created_by | String | Full name of the user who created the task assignment
 
@@ -1392,8 +1392,8 @@ JSON.parse(response)
       "confirmation_status": "completed",
       "status": "completed",
       "time_to_perform_minutes": 105.5,
-      "datetime_start": "2025-03-10 09:05:00",
-      "datetime_end": "2025-03-10 10:45:00",
+      "response_start": "2025-03-10 09:05:00",
+      "response_end": "2025-03-10 10:45:00",
       "created_at": "2025-03-01 08:00:00",
       "created_by": "Admin User"
     }
@@ -1453,8 +1453,8 @@ mandatory | String | `for_nobody`, `for_one`, or `for_everyone`
 confirmation_status | String | Acceptance state: `required`, `accepted`, `rejected`, `completed`, or `null`
 status | String | Task state: `completed`, `incomplete`, `assigned`, `accepted`, or `rejected`
 time_to_perform_minutes | Float | Minutes between first and last answer submission. `null` if not completed
-datetime_start | String | When the first answer was submitted (account timezone)
-datetime_end | String | When the last answer was submitted (account timezone)
+response_start | String | When the first answer was submitted (account timezone)
+response_end | String | When the last answer was submitted (account timezone)
 created_at | String | When the task assignment was created (account timezone)
 created_by | String | Full name of the user who created the task assignment
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1327,7 +1327,7 @@ completed_datetime | String | When the last answer was submitted (account timezo
 late_response_allowed | Boolean | Whether late submissions are permitted
 mandatory | String | `for_nobody`, `for_one`, or `for_everyone`
 confirmation_status | String | Acceptance state: `required`, `accepted`, `rejected`, `completed`, or `null`
-status | String | Task state: `completed`, `incomplete`, `sent`, `in_progress`, or `rejected`
+status | String | Task state: `completed`, `incomplete`, `assigned`, `accepted`, or `rejected`
 time_to_perform_minutes | Float | Minutes between first and last answer submission. `null` if not completed
 datetime_start | String | When the first answer was submitted (account timezone)
 datetime_end | String | When the last answer was submitted (account timezone)
@@ -1401,7 +1401,7 @@ JSON.parse(response)
 }
 ```
 
-This endpoint retrieves a paginated list of task assignments for the authenticated account. The response fields match the platform's Excel export plus the internal `id`, enabling automated integrations without manual downloads.
+This endpoint retrieves a paginated list of task assignments for the authenticated account. The response fields match the platform's Excel export plus the internal `id`, enabling automated integrations without manual downloads. The `total` field reflects the number of task assignments matching the applied filters — without filters, it returns the count of all historical tasks in the account.
 
 ### HTTP Request
 
@@ -1413,7 +1413,7 @@ Parameter | Type | Description
 --------- | ------- | -----------
 start_date | String | Optional. Start date in `YYYY-MM-DD` format. Filters by `start_time >= date`
 end_date | String | Optional. End date in `YYYY-MM-DD` format. Filters by `start_time <= date`
-status | String | Optional. Filter by status: `completed`, `incomplete`, `sent`, `in_progress`, `rejected`
+status | String | Optional. Filter by status: `completed`, `incomplete`, `assigned`, `accepted`, `rejected`
 location_id | Integer | Optional. Filter by location ID
 user_email | String | Optional. Filter by the assigned inspector's email
 limit | Integer | Optional. Max number of results to return. Default: 100, max: 300
@@ -1447,12 +1447,16 @@ completed_datetime | String | When the last answer was submitted (account timezo
 late_response_allowed | Boolean | Whether late submissions are permitted
 mandatory | String | `for_nobody`, `for_one`, or `for_everyone`
 confirmation_status | String | Acceptance state: `required`, `accepted`, `rejected`, `completed`, or `null`
-status | String | Task state: `completed`, `incomplete`, `sent`, `in_progress`, or `rejected`
+status | String | Task state: `completed`, `incomplete`, `assigned`, `accepted`, or `rejected`
 time_to_perform_minutes | Float | Minutes between first and last answer submission. `null` if not completed
 datetime_start | String | When the first answer was submitted (account timezone)
 datetime_end | String | When the last answer was submitted (account timezone)
 created_at | String | When the task assignment was created (account timezone)
 created_by | String | Full name of the user who created the task assignment
+
+<aside class="notice">
+When no `start_date` / `end_date` filters are provided, this endpoint returns <strong>all historical task assignments</strong> for the account. The platform UI applies a default ±7-day window, so counts may differ. Use date filters to match the UI view.
+</aside>
 
 <aside class="success">
 Remember — use your own Authorization header

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1338,6 +1338,126 @@ created_by | String | Full name of the user who created the task assignment
 Remember — use your own Authorization header
 </aside>
 
+## Get Task Assigns by Period
+
+```shell
+curl "https://www.mydatascope.com/api/external/task_assigns?start_date=2025-03-01&end_date=2025-03-31" \
+  -H "Authorization: b1cd93mfls9fdmfkadn23"
+```
+
+```ruby
+require 'rest-client'
+require 'json'
+
+url = 'https://www.mydatascope.com/api/external/task_assigns'
+response = RestClient.get url, {
+  :Authorization => 'b1cd93mfls9fdmfkadn23',
+  :params => { start_date: '2025-03-01', end_date: '2025-03-31' }
+}
+JSON.parse(response)
+```
+
+> The above command returns JSON structured like this, you can check the description of each parameter below:
+
+```json
+{
+  "task_assigns": [
+    {
+      "id": 4821,
+      "assign_id": "TA-2024-001",
+      "form_answer_code": "FA-0099",
+      "start_time": "2025-03-10 09:00:00",
+      "form_name": "Safety Inspection",
+      "user_email": "inspector@company.com",
+      "description": "Monthly fire extinguisher check",
+      "location_name": "Main Warehouse",
+      "location_code": "WH-001",
+      "location_type": "Location",
+      "location_address": "123 Main Ave",
+      "location_email": "warehouse@company.com",
+      "location_phone": "+1-555-0100",
+      "gap": 2,
+      "checklist": "Check extinguisher,Verify seal,Sign log",
+      "location_latitude": -33.4489,
+      "location_longitude": -70.6693,
+      "completed": "Yes",
+      "on_time": "Yes",
+      "delay_time": "0d/00h/00m",
+      "completed_datetime": "2025-03-10 10:45:00",
+      "late_response_allowed": false,
+      "mandatory": "for_everyone",
+      "confirmation_status": "completed",
+      "status": "completed",
+      "time_to_perform_minutes": 105.5,
+      "datetime_start": "2025-03-10 09:05:00",
+      "datetime_end": "2025-03-10 10:45:00",
+      "created_at": "2025-03-01 08:00:00",
+      "created_by": "Admin User"
+    }
+  ],
+  "total": 1,
+  "limit": 100,
+  "offset": 0
+}
+```
+
+This endpoint retrieves a paginated list of task assignments for the authenticated account. The response fields match the platform's Excel export plus the internal `id`, enabling automated integrations without manual downloads.
+
+### HTTP Request
+
+`GET https://www.mydatascope.com/api/external/task_assigns`
+
+### Input Parameters
+
+Parameter | Type | Description
+--------- | ------- | -----------
+start_date | String | Optional. Start date in `YYYY-MM-DD` format. Filters by `start_time >= date`
+end_date | String | Optional. End date in `YYYY-MM-DD` format. Filters by `start_time <= date`
+status | String | Optional. Filter by status: `completed`, `incomplete`, `sent`, `in_progress`, `rejected`
+location_id | Integer | Optional. Filter by location ID
+user_email | String | Optional. Filter by the assigned inspector's email
+limit | Integer | Optional. Max number of results to return. Default: 100, max: 300
+offset | Integer | Optional. Number of results to skip (for pagination). Default: 0
+
+### Response Fields
+
+Field | Type | Description
+--------- | ------- | -----------
+id | Integer | Internal database ID — unique across all periods
+assign_id | String | User-defined task code — may repeat across periods
+form_answer_code | String | Code of the submitted form answer, if completed
+start_time | String | Scheduled start time (account timezone)
+form_name | String | Name of the associated form
+user_email | String | Email of the assigned inspector
+description | String | Task description or instructions
+location_name | String | Name of the location
+location_code | String | Code of the location
+location_type | String | `Location` or `NestableLocation`
+location_address | String | Address of the location
+location_email | String | Email of the location
+location_phone | String | Phone of the location
+gap | Integer | Estimated hours to perform the task
+checklist | String | Comma-separated checklist items
+location_latitude | Float | Latitude of the location
+location_longitude | Float | Longitude of the location
+completed | String | `Yes` if a form answer exists, `No` otherwise
+on_time | String | `Yes` if completed before deadline, `No` if late, `null` if not completed
+delay_time | String | Delay formatted as `Xd/HHh/MMm`. `null` if not completed
+completed_datetime | String | When the last answer was submitted (account timezone)
+late_response_allowed | Boolean | Whether late submissions are permitted
+mandatory | String | `for_nobody`, `for_one`, or `for_everyone`
+confirmation_status | String | Acceptance state: `required`, `accepted`, `rejected`, `completed`, or `null`
+status | String | Task state: `completed`, `incomplete`, `sent`, `in_progress`, or `rejected`
+time_to_perform_minutes | Float | Minutes between first and last answer submission. `null` if not completed
+datetime_start | String | When the first answer was submitted (account timezone)
+datetime_end | String | When the last answer was submitted (account timezone)
+created_at | String | When the task assignment was created (account timezone)
+created_by | String | Full name of the user who created the task assignment
+
+<aside class="success">
+Remember — use your own Authorization header
+</aside>
+
 # Notifications
 
 ## List Last notifications


### PR DESCRIPTION
## Summary
- Rename `start_date` parameter to `start` and `end_date` to `end` in the task assigns API documentation
- Updated curl example, Ruby example, and input parameters table

## Test plan
- [ ] Verify docs site renders correctly with updated parameter names
- [ ] Confirm examples match the backend API parameter names

🤖 Generated with [Claude Code](https://claude.com/claude-code)